### PR TITLE
Added a script for querying the RAG database

### DIFF
--- a/scripts/query_rag.py
+++ b/scripts/query_rag.py
@@ -1,0 +1,47 @@
+"""Utility script for querying RAG database."""
+
+import argparse
+import os
+
+from llama_index.core.storage.storage_context import StorageContext
+from llama_index.core import Settings, load_index_from_storage
+from llama_index.core.schema import NodeWithScore
+from llama_index.vector_stores.faiss import FaissVectorStore
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Utility script for querying RAG database"
+    )
+    parser.add_argument(
+        "-p",
+        "--db-path",
+        required=True,
+        help="path to the vector db",
+    )
+    parser.add_argument("-x", "--product-index", required=True, help="product index")
+    parser.add_argument(
+        "-m", "--model-path", required=True, help="path to the embedding model"
+    )
+    parser.add_argument("-q", "--query", required=True, help="query to run")
+    parser.add_argument(
+        "-k", "--top-k", type=int, required=True, help="similarity_top_k"
+    )
+    args = parser.parse_args()
+
+    os.environ["TRANSFORMERS_CACHE"] = args.model_path
+    os.environ["TRANSFORMERS_OFFLINE"] = "1"
+
+    Settings.llm = None
+    Settings.embed_model = HuggingFaceEmbedding(model_name=args.model_path)
+
+    vector_index = load_index_from_storage(
+        storage_context=StorageContext.from_defaults(
+            vector_store=FaissVectorStore.from_persist_dir(args.db_path),
+            persist_dir=args.db_path,
+        ),
+        index_id=args.product_index,
+    )
+    retriever = vector_index.as_retriever(similarity_top_k=args.top_k)
+    for n in retriever.retrieve(args.query):
+        print(n.__repr__())


### PR DESCRIPTION
Added a script for querying the RAG database: scripts/query_rag.py. Usage example:
```
$ python scripts/query_rag.py -p ~/lightspeed-config/vector_db/ocp_product_docs/4.15 -x ocp-product-docs-4_15
 -m ~/lightspeed-config/embeddings_model -q "what is kubernetes?" -k 5
LLM is explicitly disabled. Using MockLLM.
NodeWithScore(node=TextNode(id_='36d30b35-1440-4372-b2b8-1cbff69a70fd', embedding=None, metadata={'docs_url':
 'https://docs.openshift.com/container-platform/4.15/architecture/architecture.html', 'title': '"Red Hat OpenShift Container 
Platform" architecture'}, excluded_embed_metadata_keys=['file_name', 'file_type', 'file_size', 'creation_date', 
'last_modified_date', 'last_accessed_date'], excluded_llm_metadata_keys=['file_name', 'file_type', 'file_size', 'creation_date', 
'last_modified_date', 'last_accessed_date'], relationships={<NodeRelationship.SOURCE: '1'>: 
RelatedNodeInfo(node_id='90a02190-82b6-4f7f-b9af-02a792147b3a', node_type=<ObjectType.DOCUMENT: '4'>, 
metadata={'docs_url': 'https://docs.openshift.com/container-platform/4.15/architecture/architecture.html', 'title': '"Red Hat 
OpenShift Container Platform" architecture'}, 
hash='0f2d57fb150516fdadd97d59f3ecf212309e4eb20dc4a808305b1d15f370a2aa'), <NodeRelationship.PREVIOUS: '2'>: 
RelatedNodeInfo(node_id='1eb00dd8-f210-454d-909d-ce0b367c7579', node_type=<ObjectType.TEXT: '1'>, 
metadata={'docs_url': 'https://docs.openshift.com/container-platform/4.15/architecture/architecture-rhcos.html', 'title': 
'Red Hat Enterprise Linux CoreOS (RHCOS)'}, 
hash='c448c0ff131b273cd02470dc04f769849f859fcf94dac3916a60a6e681315d97'), <NodeRelationship.NEXT: '3'>: 
RelatedNodeInfo(node_id='925741e5-fe11-4af9-ad08-d6a68a447814', node_type=<ObjectType.TEXT: '1'>, metadata={}, 
hash='2494daed591555b62384af6aa0ef4beb8506af566a02b7
text='"Red Hat OpenShift Container Platform" architecture\n\nIntroduction to "Red Hat OpenShift Container
Platform"\n"Red Hat OpenShift Container Platform" is a platform for developing and running containerized applications.
It is designed to allow applications and the data centers that support them to expand from just a...
start_char_idx=0, end_char_idx=6873, text_template='{metadata_str}\n\n{content}', metadata_template='{key}: {value}', 
metadata_seperator='\n'), score=0.5366535186767578)
...
```
