### PR TITLE
Delete the local copy of the OCP docs before update

### DIFF
--- a/scripts/get_ocp_plaintext_docs.sh
+++ b/scripts/get_ocp_plaintext_docs.sh
@@ -5,6 +5,8 @@ OCP_VERSION=$1
 
 trap "rm -rf openshift-docs" EXIT
 
+rm -rf ocp-product-docs-plaintext
+
 git clone --single-branch --branch enterprise-${OCP_VERSION} https://github.com/openshift/openshift-docs.git
 
 echo "product-version: $OCP_VERSION" >> scripts/asciidoctor-text/attributes.yaml


### PR DESCRIPTION
In the scripts/get_ocp_plaintext_docs.sh script, delete the local copy of the docs so that the pages deleted in the upstream end up deleted in the local copy.