### PR TITLE
OLS-517: Handle encoded/image data in index

### DIFF
--- a/scripts/generate_embeddings.py
+++ b/scripts/generate_embeddings.py
@@ -61,6 +61,15 @@ def file_metadata_func(file_path: str) -> Dict:
     return {"docs_url": docs_url, "title": title}
 
 
+def got_whitespace(text: str) -> bool:
+    """Indicate if the parameter string contains whitespace."""
+
+    for c in node.text:
+        if c.isspace():
+            return True
+    return False
+
+
 if __name__ == "__main__":
 
     start_time = time.time()
@@ -111,8 +120,16 @@ if __name__ == "__main__":
         args.folder, recursive=True, file_metadata=file_metadata_func
     ).load_data()
 
-    index = VectorStoreIndex.from_documents(
-        documents,
+    good_nodes = []
+    nodes = Settings.text_splitter.get_nodes_from_documents(documents)
+    for node in nodes:
+        if got_whitespace(node.text):
+            good_nodes.append(node)
+        else:
+            print("skipping bad node: " + node.__repr__())
+
+    index = VectorStoreIndex(
+        good_nodes,
         storage_context=storage_context,
     )
     index.set_index_id(args.index)

--- a/scripts/generate_embeddings.py
+++ b/scripts/generate_embeddings.py
@@ -19,14 +19,18 @@ OCP_DOCS_VERSION = "4.15"
 UNREACHABLE_DOCS: bool = False
 
 def ping_url(url: str) -> bool:
+    """Check if the URL parameter is live."""
+
     try:
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         return response.status_code == 200
     except requests.exceptions.RequestException:
         return False
 
 
 def get_file_title(file_path: str) -> str:
+    """Extract title from the plaintext doc file."""
+
     title = ""
     try:
         with open(file_path, 'r') as file:

--- a/scripts/query_rag.py
+++ b/scripts/query_rag.py
@@ -5,7 +5,6 @@ import os
 
 from llama_index.core.storage.storage_context import StorageContext
 from llama_index.core import Settings, load_index_from_storage
-from llama_index.core.schema import NodeWithScore
 from llama_index.vector_stores.faiss import FaissVectorStore
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 
@@ -23,10 +22,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "-m", "--model-path", required=True, help="path to the embedding model"
     )
-    parser.add_argument("-q", "--query", required=True, help="query to run")
+    parser.add_argument("-q", "--query", help="query to run")
     parser.add_argument(
-        "-k", "--top-k", type=int, required=True, help="similarity_top_k"
+        "-k", "--top-k", type=int, help="similarity_top_k"
     )
+    parser.add_argument("-n", "--node", help="retrieve node")
     args = parser.parse_args()
 
     os.environ["TRANSFORMERS_CACHE"] = args.model_path
@@ -35,13 +35,17 @@ if __name__ == "__main__":
     Settings.llm = None
     Settings.embed_model = HuggingFaceEmbedding(model_name=args.model_path)
 
+    storage_context=StorageContext.from_defaults(
+        vector_store=FaissVectorStore.from_persist_dir(args.db_path),
+        persist_dir=args.db_path,
+    )
     vector_index = load_index_from_storage(
-        storage_context=StorageContext.from_defaults(
-            vector_store=FaissVectorStore.from_persist_dir(args.db_path),
-            persist_dir=args.db_path,
-        ),
+        storage_context=storage_context,
         index_id=args.product_index,
     )
-    retriever = vector_index.as_retriever(similarity_top_k=args.top_k)
-    for n in retriever.retrieve(args.query):
-        print(n.__repr__())
+    if args.node is not None:
+        print(storage_context.docstore.get_node(args.node).__repr__())
+    else:
+        retriever = vector_index.as_retriever(similarity_top_k=args.top_k)
+        for n in retriever.retrieve(args.query):
+            print(n.__repr__())


### PR DESCRIPTION
- Added a timeout to the docs URL liveness check
- Added detection of bad nodes: base64 chunks.
  These are marked with `bad_node = 1` metadata label and are listed in the metadata.json file
- Added support for node lookup by node id