### PR TITLE
Improvements to OCP docs plain text generation:

### DIFF
--- a/scripts/asciidoctor-text/attributes.yaml
+++ b/scripts/asciidoctor-text/attributes.yaml
@@ -1,1 +1,201 @@
 product-title: Red Hat OpenShift Container Platform
+data-uri:
+icons:
+experimental:
+toc: macro
+toc-title:
+imagesdir: images
+prewrap!:
+op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
+op-system: RHCOS
+op-system-lowercase: rhcos
+op-system-base: RHEL
+op-system-base-full: Red Hat Enterprise Linux (RHEL)
+op-system-version: 8.x
+tsb-name: Template Service Broker
+kebab: .
+rh-openstack-first: Red Hat OpenStack Platform (RHOSP)
+rh-openstack: RHOSP
+ai-full: Assisted Installer
+ai-version: 2.3
+cluster-manager-first: Red Hat OpenShift Cluster Manager
+cluster-manager: OpenShift Cluster Manager
+cluster-manager-url: https://console.redhat.com/openshift [OpenShift Cluster Manager Hybrid Cloud Console]
+cluster-manager-url-pull: https://console.redhat.com/openshift/install/pull-secret [pull secret from the Red Hat OpenShift Cluster Manager]
+insights-advisor-url: https://console.redhat.com/openshift/insights/advisor/ [Insights Advisor]
+hybrid-console: Red Hat Hybrid Cloud Console
+hybrid-console-second: Hybrid Cloud Console
+oadp-first: OpenShift API for Data Protection (OADP)
+oadp-full: OpenShift API for Data Protection
+oc-first: OpenShift CLI (`oc`)
+product-registry: OpenShift image registry
+rh-storage-first: Red Hat OpenShift Data Foundation
+rh-storage: OpenShift Data Foundation
+rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)
+rh-rhacm: RHACM
+rh-rhacm-version: 2.8
+sandboxed-containers-first: OpenShift sandboxed containers
+sandboxed-containers-operator: OpenShift sandboxed containers Operator
+sandboxed-containers-version: 1.3
+sandboxed-containers-version-z: 1.3.3
+sandboxed-containers-legacy-version: 1.3.2
+cert-manager-operator: cert-manager Operator for Red Hat OpenShift
+secondary-scheduler-operator-full: Secondary Scheduler Operator for Red Hat OpenShift
+secondary-scheduler-operator: Secondary Scheduler Operator
+velero-domain: velero.io
+velero-version: 1.11
+launch: Application Launcher
+mtc-short: MTC
+mtc-full: Migration Toolkit for Containers
+mtc-version: 1.8
+mtc-version-z: 1.8.0
+builds-v2title: Builds for Red Hat OpenShift
+builds-v2shortname: OpenShift Builds v2
+builds-v1shortname: OpenShift Builds v1
+gitops-title: Red Hat OpenShift GitOps
+gitops-shortname: GitOps
+gitops-ver: 1.1
+rh-app-icon: Red Hat applications
+pipelines-title: Red Hat OpenShift Pipelines
+pipelines-shortname: OpenShift Pipelines
+pipelines-ver: pipelines-1.12
+pipelines-version-number: 1.12
+tekton-chains: Tekton Chains
+tekton-hub: Tekton Hub
+artifact-hub: Artifact Hub
+pac: Pipelines as Code
+odo-title: odo
+oke: OpenShift Kubernetes Engine
+opp: OpenShift Platform Plus
+VirtProductName: OpenShift Virtualization
+VirtVersion: 4.14
+KubeVirtVersion: v0.59.0
+HCOVersion: 4.14.0
+CNVNamespace: openshift-cnv
+CNVOperatorDisplayName: OpenShift Virtualization Operator
+CNVSubscriptionSpecSource: redhat-operators
+CNVSubscriptionSpecName: kubevirt-hyperconverged
+delete: Delete
+DTProductName: Red Hat OpenShift distributed tracing platform
+DTShortName: distributed tracing platform
+DTProductVersion: 2.9
+JaegerName: Red Hat OpenShift distributed tracing platform (Jaeger)
+JaegerShortName: distributed tracing platform (Jaeger)
+JaegerVersion: 1.47.0
+OTELName: Red Hat OpenShift distributed tracing data collection
+OTELShortName: distributed tracing data collection
+OTELOperator: Red Hat OpenShift distributed tracing data collection Operator
+OTELVersion: 0.81.0
+TempoName: Red Hat OpenShift distributed tracing platform (Tempo)
+TempoShortName: distributed tracing platform (Tempo)
+TempoOperator: Tempo Operator
+TempoVersion: 2.1.1
+logging-title: logging subsystem for Red Hat OpenShift
+logging-title-uc: Logging subsystem for Red Hat OpenShift
+logging: logging subsystem
+logging-uc: Logging subsystem
+clo: Red Hat OpenShift Logging Operator
+loki-op: Loki Operator
+es-op: Elasticsearch Operator
+ServerlessProductName: OpenShift Serverless
+ServerlessProductShortName: Serverless
+ServerlessOperatorName: OpenShift Serverless Operator
+FunctionsProductName: OpenShift Serverless Functions
+product-dedicated: Red Hat OpenShift Dedicated
+product-rosa: Red Hat OpenShift Service on AWS
+SMProductName: Red Hat OpenShift Service Mesh
+SMProductShortName: Service Mesh
+SMProductVersion: 2.4.4
+MaistraVersion: 2.4
+SMProductVersion1x: 1.1.18.2
+productwinc: Red Hat OpenShift support for Windows Containers
+rhq-cso: Red Hat Quay Container Security Operator
+quay: Red Hat Quay
+sno: single-node OpenShift
+sno-caps: Single-node OpenShift
+cgu-operator-first: Topology Aware Lifecycle Manager (TALM)
+cgu-operator-full: Topology Aware Lifecycle Manager
+cgu-operator: TALM
+redfish-operator: Bare Metal Event Relay
+openshift-local-productname: Red Hat OpenShift Local
+openshift-dev-spaces-productname: Red Hat OpenShift Dev Spaces
+factory-prestaging-tool: factory-precaching-cli tool
+factory-prestaging-tool-caps: Factory-precaching-cli tool
+openshift-networking: Red Hat OpenShift Networking
+lvms-first: Logical volume manager storage (LVM Storage)
+lvms: LVM Storage
+osdk_ver: 1.31.0
+osdk_ver_n1: 1.28.0
+olmv1: OLM 1.0
+olmv1-first: Operator Lifecycle Manager (OLM) 1.0
+ztp-first: GitOps Zero Touch Provisioning (ZTP)
+ztp: GitOps ZTP
+3no: three-node OpenShift
+3no-caps: Three-node OpenShift
+run-once-operator: Run Once Duration Override Operator
+web-terminal-op: Web Terminal Operator
+devworkspace-op: DevWorkspace Operator
+secrets-store-driver: Secrets Store CSI driver
+secrets-store-operator: Secrets Store CSI Driver Operator
+sts-first: Security Token Service (STS)
+sts-full: Security Token Service
+sts-short: STS
+aws-first: Amazon Web Services (AWS)
+aws-full: Amazon Web Services
+aws-short: AWS
+gcp-first: Google Cloud Platform (GCP)
+gcp-full: Google Cloud Platform
+gcp-short: GCP
+alibaba: Alibaba Cloud
+ibm-name: IBM(R)
+ibm-title: IBM
+ibm-cloud-name: IBM Cloud(R)
+ibm-cloud-title: IBM Cloud
+ibm-cloud-bm: IBM Cloud(R) Bare Metal (Classic)
+ibm-cloud-bm-title: IBM Cloud Bare Metal (Classic)
+ibm-power-name: IBM Power(R)
+ibm-power-title: IBM Power
+ibm-power-server-name: IBM Power(R) Virtual Server
+ibm-power-server-title: IBM Power Virtual Server
+ibm-z-name: IBM Z(R)
+ibm-z-title: IBM Z
+ibm-linuxone-name: IBM(R) LinuxONE
+ibm-linuxone-title: IBM LinuxONE
+azure-full: Microsoft Azure
+azure-short: Azure
+vmw-full: VMware vSphere
+vmw-short: vSphere
+oci-first: Oracle(R) Cloud Infrastructure
+oci: OCI
+ocvs-first: Oracle(R) Cloud VMware Solution (OCVS)
+ocvs: OCVS
+rh-openstack-first: OpenStack
+rh-openstack: OpenStack
+vmw-first: VMware vSphere
+vmw-full: VMware vSphere
+vmw-short: vSphere
+sts-first: Security Token Service (STS)
+sts-full: Security Token Service
+sts-short: STS
+entra-first: Microsoft Entra Workload ID
+entra-short: Workload ID
+cap-aws-first: Cluster API Provider Amazon Web Services (AWS)
+cap-aws-short: Cluster API Provider AWS
+cap-gcp-first: Cluster API Provider Google Cloud Platform (GCP)
+cap-gcp-short: Cluster API Provider GCP
+cap-ibm-first: Cluster API Provider IBM Cloud
+cap-ibm-short: Cluster API Provider IBM Cloud
+cap-kubevirt-first: Cluster API Provider Kubevirt
+cap-kubevirt-short: Cluster API Provider Kubevirt
+cap-azure-first: Cluster API Provider Microsoft Azure
+cap-azure-short: Cluster API Provider Azure
+cap-nutanix-first: Cluster API Provider Nutanix
+cap-nutanix-short: Cluster API Provider Nutanix
+cap-openstack-first: Cluster API Provider OpenStack
+cap-openstack-short: Cluster API Provider OpenStack
+cap-oci-first: Cluster API Provider Oracle Cloud Infrastructure (OCI)
+cap-oci-short: Cluster API Provider OCI
+cap-vsphere-first: Cluster API Provider VMware vSphere
+cap-vsphere-short: Cluster API Provider vSphere
+hcp-capital: Hosted control planes
+hcp: hosted control planes

--- a/scripts/asciidoctor-text/convert-it-all.py
+++ b/scripts/asciidoctor-text/convert-it-all.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
         with open(args.attributes, "r") as fin:
             attributes = yaml.safe_load(fin)
         for key, value in attributes.items():
-            attribute_list = [*attribute_list, "-a", key + '="%s"' % value]
+            attribute_list = [*attribute_list, "-a", key + '=%s' % value]
 
     with open(args.topic_map, "r") as fin:
         topic_map = yaml.safe_load_all(fin)

--- a/scripts/asciidoctor-text/text-converter.rb
+++ b/scripts/asciidoctor-text/text-converter.rb
@@ -58,6 +58,7 @@ class Converter::TextConverter < Converter::Base
         gsub('&gt;', '>').
         gsub('&#43;', '+').      # plus sign; alternately could use \c(pl
         gsub('&#160;', ' ').    # non-breaking space
+        gsub('&#174;', '(R)').    # registered trademark        
         gsub('&#8201;', ' ').    # thin space
         gsub('&#8211;', '-'). # en dash
         gsub('&#8212;', '-'). # em dash

--- a/scripts/generate_embeddings.py
+++ b/scripts/generate_embeddings.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
         if isinstance(node, TextNode) and got_whitespace(node.text):
             good_nodes.append(node)
         else:
-            print("skipping bad node: " + node.__repr__())
+            print("skipping node without whitespace: " + node.__repr__())
 
     index = VectorStoreIndex(
         good_nodes,


### PR DESCRIPTION
Improvements to OCP docs plain text generation:

- Brought attributes from openshift-docs/blob/enterprise-4.15/_attributes/common-attributes.adoc
- Removed surrounding double quotes from attribute values in the generated plaintext
- Added handling of (R) (registered trademark) sign
- "bad nodes" are now "nodes without whitespace" during embeddings generation