### PR TITLE
Fix for Konflux error: invalid input params for task deprecated-image-check

### DIFF
--- a/.tekton/lightspeed-rag-content-pull-request.yaml
+++ b/.tekton/lightspeed-rag-content-pull-request.yaml
@@ -281,6 +281,10 @@ spec:
           value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.3@sha256:ae1fcb32b1aeac846e1a41019b2e735b9c25c27752496f17744d869860c80ff1
         - name: kind
           value: task
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
         resolver: bundles
       when:
       - input: $(params.skip-checks)


### PR DESCRIPTION
Fix for Konflux error: 
```
[User error] Validation failed for pipelinerun lightspeed-rag-content-on-pull-request-7v8q7 with error invalid
input params for task deprecated-image-check: missing values for these params which have no default
values: [IMAGE_URL IMAGE_DIGEST]
```