### PR TITLE
Konflux: migration from 0.3 to 0.4

### DIFF
--- a/.tekton/lightspeed-rag-content-pull-request.yaml
+++ b/.tekton/lightspeed-rag-content-pull-request.yaml
@@ -271,6 +271,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - build-container
       taskRef:
@@ -281,10 +285,6 @@ spec:
           value: quay.io/redhat-appstudio-tekton-catalog/task-deprecated-image-check:0.3@sha256:ae1fcb32b1aeac846e1a41019b2e735b9c25c27752496f17744d869860c80ff1
         - name: kind
           value: task
-        - name: image-digest
-          value: $(tasks.build-container.results.IMAGE_DIGEST)
-        - name: image-url
-          value: $(tasks.build-container.results.IMAGE_URL)
         resolver: bundles
       when:
       - input: $(params.skip-checks)

--- a/.tekton/lightspeed-rag-content-push.yaml
+++ b/.tekton/lightspeed-rag-content-push.yaml
@@ -268,6 +268,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)	
       runAfter:
       - build-container
       taskRef:


### PR DESCRIPTION
Fix for 
```
[User error] Validation failed for pipelinerun lightspeed-rag-content-on-pull-request-x2sqp with error
invalid input params for task deprecated-image-check: missing values for these params which have no
default values: [IMAGE_URL IMAGE_DIGEST]
```
according to https://github.com/konflux-ci/build-definitions/blob/main/task/deprecated-image-check/0.4/MIGRATION.md