### PR TITLE
In Konflux, increase timeout on the build-container task and the overall pipeline timeout

### DIFF
--- a/.tekton/lightspeed-rag-content-pull-request.yaml
+++ b/.tekton/lightspeed-rag-content-pull-request.yaml
@@ -31,8 +31,8 @@ spec:
   - name: revision
     value: '{{revision}}'
   timeouts:
-    pipeline: "2h0m0s"
-    tasks: "2h0m0s"
+    pipeline: "4h0m0s"
+    tasks: "4h0m0s"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -221,6 +221,7 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       runAfter:
       - prefetch-dependencies
+      timeout: "3h0m0s"
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
In Konflux, increase timeout on the build-container task and the overall pipeline timeout.