### PR TITLE
OLS-558: modify rag chunking

### DIFF
--- a/.tekton/lightspeed-rag-content-pull-request.yaml
+++ b/.tekton/lightspeed-rag-content-pull-request.yaml
@@ -31,8 +31,8 @@ spec:
   - name: revision
     value: '{{revision}}'
   timeouts:
-    pipeline: "4h0m0s"
-    tasks: "4h0m0s"
+    pipeline: "9h0m0s"
+    tasks: "9h0m0s"
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -221,7 +221,7 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       runAfter:
       - prefetch-dependencies
-      timeout: "3h0m0s"
+      timeout: "8h0m0s"
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
Reduce chunk size. [OLS-558](https://issues.redhat.com//browse/OLS-558)

Below changes were added, but commented out (not removing, eventually we may end up doing this)

- Split document as per header & section. [OLS-601](https://issues.redhat.com//browse/OLS-601)
- Ability to exclude metadata during embedding. [OLS-609](https://issues.redhat.com//browse/OLS-609)

Konflux pipeline takes really long time now with these changes, as we are processing large number of smaller chunks for 2 different OCP doc version.. We will have to figure out how we can reduce the pipeline execution time. Meanwhile timeout duration is increased significantly in order to keep reduced chunk size changes, which is important (Other 2 changes are not that important, so commented out)