### PR TITLE
OLS-1255: Fix rag-content Tekton descriptors to make the renovate bot happy

### DIFF
--- a/.tekton/lightspeed-rag-content-pull-request.yaml
+++ b/.tekton/lightspeed-rag-content-pull-request.yaml
@@ -407,11 +407,6 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/lightspeed-rag-content-push.yaml
+++ b/.tekton/lightspeed-rag-content-push.yaml
@@ -405,11 +405,6 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       params:
       - name: image-digest


### PR DESCRIPTION
This must be a merge gone wrong at some point in the past. The renovate bot silently failed to parse .tekton/lightspeed-rag-content-pu*.yaml and stopped updating the Konflux task references.