### PR TITLE
OLS-1271: Add project and org to the Konflux Snyk task

### DIFF
--- a/.tekton/lightspeed-rag-content-pull-request.yaml
+++ b/.tekton/lightspeed-rag-content-pull-request.yaml
@@ -397,6 +397,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ARGS
+        value: "--project-name=lightspeed-rag-content --report --org=dca2ca89-7e51-4a3a-b7a5-6ad5633057b8"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/lightspeed-rag-content-push.yaml
+++ b/.tekton/lightspeed-rag-content-push.yaml
@@ -395,6 +395,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ARGS
+        value: "--project-name=lightspeed-rag-content --report --org=dca2ca89-7e51-4a3a-b7a5-6ad5633057b8"
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Add project and org to the Konflux Snyk task so Snyk scan results are sent to snyk.io.