### PR TITLE
[Test fix ] turn off hermetic build to verify the missing files in service

### DIFF
--- a/.tekton/lightspeed-rag-content-pull-request.yaml
+++ b/.tekton/lightspeed-rag-content-pull-request.yaml
@@ -32,9 +32,9 @@ spec:
   - name: prefetch-input
     value: '[{"type": "generic", "path": "."}, {"type": "rpm", "path": "."}, {"type": "pip", "path": ".", "allow_binary": "true"}]'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-args
-    value: [FLAVOR=gpu, HERMETIC=true]
+    value: [FLAVOR=gpu, HERMETIC=false]
   timeouts:
     pipeline: "4h0m0s"
     tasks: "4h0m0s"

--- a/.tekton/lightspeed-rag-content-push.yaml
+++ b/.tekton/lightspeed-rag-content-push.yaml
@@ -30,9 +30,9 @@ spec:
   - name: prefetch-input
     value: '[{"type": "generic", "path": "."}, {"type": "rpm", "path": "."}, {"type": "pip", "path": ".", "allow_binary": "true"}]'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-args
-    value: [FLAVOR=gpu, HERMETIC=true]
+    value: [FLAVOR=gpu, HERMETIC=false]
   timeouts:
     pipeline: "4h0m0s"
     tasks: "4h0m0s"

--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,7 @@ ARG FLAVOR
 FROM nvcr.io/nvidia/cuda:12.6.2-devel-ubi9 as gpu-base
 ARG EMBEDDING_MODEL
 ARG FLAVOR
-RUN dnf install -y python3.11 python3.11-pip libcudnn9 libnccl
+RUN dnf install -y python3.11 python3.11-pip libcudnn9 libnccl wget
 
 FROM ${FLAVOR}-base as lightspeed-rag-builder
 ARG EMBEDDING_MODEL


### PR DESCRIPTION
Turning off hermetic build to see if we can produce the artifacts that is missing in service.
```
OSError: Error no file named pytorch_model.bin, tf_model.h5, model.ckpt.index or flax_model.msgpack found in directory /app-root/embeddings_model.
```