### PR TITLE
[Temp/Test]: use non-hermetic build & use curl to get safetensors.

### DIFF
--- a/.tekton/lightspeed-rag-content-pull-request.yaml
+++ b/.tekton/lightspeed-rag-content-pull-request.yaml
@@ -32,9 +32,9 @@ spec:
   - name: prefetch-input
     value: '[{"type": "generic", "path": "."}, {"type": "rpm", "path": "."}, {"type": "pip", "path": ".", "allow_binary": "true"}]'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-args
-    value: [FLAVOR=gpu, HERMETIC=true]
+    value: [FLAVOR=gpu, HERMETIC=false]
   timeouts:
     pipeline: "4h0m0s"
     tasks: "4h0m0s"

--- a/.tekton/lightspeed-rag-content-push.yaml
+++ b/.tekton/lightspeed-rag-content-push.yaml
@@ -30,9 +30,9 @@ spec:
   - name: prefetch-input
     value: '[{"type": "generic", "path": "."}, {"type": "rpm", "path": "."}, {"type": "pip", "path": ".", "allow_binary": "true"}]'
   - name: hermetic
-    value: "true"
+    value: "false"
   - name: build-args
-    value: [FLAVOR=gpu, HERMETIC=true]
+    value: [FLAVOR=gpu, HERMETIC=false]
   timeouts:
     pipeline: "4h0m0s"
     tasks: "4h0m0s"

--- a/Containerfile
+++ b/Containerfile
@@ -30,7 +30,7 @@ COPY embeddings_model ./embeddings_model
 RUN cd embeddings_model; if [ "$HERMETIC" == "true" ]; then \
         ln -s /cachi2/output/deps/generic/model.safetensors model.safetensors; \
     else \
-        wget -q https://huggingface.co/sentence-transformers/all-mpnet-base-v2/resolve/9a3225965996d404b775526de6dbfe85d3368642/model.safetensors; \
+        curl -L https://huggingface.co/sentence-transformers/all-mpnet-base-v2/resolve/9a3225965996d404b775526de6dbfe85d3368642/model.safetensors --output model.safetensors; \
     fi
 
 RUN if [ "$FLAVOR" == "gpu" ]; then \


### PR DESCRIPTION
Using curl for non-hermetic build to get the safetensors file from huggingface..
Disable hermatic build till embedding model issue is fixed. (missing file) [issue with cachi2 model.safetensors.]
`OSError: Error no file named pytorch_model.bin, tf_model.h5, model.ckpt.index or flax_model.msgpack found in directory /app-root/embeddings_model.`