### PR TITLE
Pick up buildah-remote task definition that reenables GPU support

### DIFF
--- a/.tekton/lightspeed-rag-content-pull-request.yaml
+++ b/.tekton/lightspeed-rag-content-pull-request.yaml
@@ -255,7 +255,7 @@ spec:
         - name: name
           value: buildah-remote
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote:0.4@sha256:1e138efef0921ee5164d8702acfcfac2a8d6299901b812d73ffccc024c8eb605
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote:0.4@sha256:f1e6b071c6f7e47e3c6c52930872547a01672366ad91ba4ea4c44934efe011d8
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/lightspeed-rag-content-push.yaml
+++ b/.tekton/lightspeed-rag-content-push.yaml
@@ -253,7 +253,7 @@ spec:
         - name: name
           value: buildah-remote
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote:0.4@sha256:1e138efef0921ee5164d8702acfcfac2a8d6299901b812d73ffccc024c8eb605
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote:0.4@sha256:f1e6b071c6f7e47e3c6c52930872547a01672366ad91ba4ea4c44934efe011d8
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Pick up buildah-remote task definition that reenables GPU support: https://github.com/konflux-ci/build-definitions/pull/1951