### PR TITLE
KFLUXSPRT-2242: Excluded plaintext docs dirs from Syft scanning for requirements.txt

### DIFF
--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,4 @@
+exclude:
+  - "./ocp-product-docs-plaintext/**"
+  - "./runbooks/**"
+  - "./embeddings_model/**"


### PR DESCRIPTION
Excluded plaintext docs dirs from Syft scanning for requirements.txt

JIRA: https://issues.redhat.com/browse/KFLUXSPRT-2242