### PR TITLE
OLS-1340: add default symlink to the latest version of OCP docs

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -44,6 +44,8 @@ RUN export LD_LIBRARY_PATH=/usr/local/cuda-12/compat:$LD_LIBRARY_PATH; \
             -mn ${EMBEDDING_MODEL} -o vector_db/ocp_product_docs/${OCP_VERSION} \
             -i ocp-product-docs-$(echo $OCP_VERSION | sed 's/\./_/g') -v ${OCP_VERSION} -hb $HERMETIC; \
     done
+RUN LATEST_VERSION=$(ls -1 vector_db/ocp_product_docs/ | sort -V | tail -n 1) && \
+    cd vector_db/ocp_product_docs && ln -s ${LATEST_VERSION} latest
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:a50731d3397a4ee28583f1699842183d4d24fadcc565c4688487af9ee4e13a44
 COPY --from=lightspeed-rag-builder /workdir/vector_db/ocp_product_docs /rag/vector_db/ocp_product_docs


### PR DESCRIPTION
Here we add a symlink to the latest version of OCP docs' RAG index
On the service side, it will look for the `default` directory if a RAG path does not exist.