### PR TITLE
OLS-1836: BYOK tool issues with the production image

### DIFF
--- a/.tekton/lightspeed-rag-tool-pull-request.yaml
+++ b/.tekton/lightspeed-rag-tool-pull-request.yaml
@@ -40,7 +40,7 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "generic", "path": "."}, {"type": "rpm", "path": "."}, {"type":
-      "pip", "path": ".", "allow_binary": "true", "requirements_files": ["requirements.gpu.txt"]}]'
+      "pip", "path": ".", "allow_binary": "true", "requirements_files": ["requirements.cpu.txt"]}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/lightspeed-rag-tool-push.yaml
+++ b/.tekton/lightspeed-rag-tool-push.yaml
@@ -37,7 +37,7 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "generic", "path": "."}, {"type": "rpm", "path": "."}, {"type":
-      "pip", "path": ".", "allow_binary": "true", "requirements_files": ["requirements.gpu.txt"]}]'
+      "pip", "path": ".", "allow_binary": "true", "requirements_files": ["requirements.cpu.txt"]}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/byok/Containerfile.tool
+++ b/byok/Containerfile.tool
@@ -1,4 +1,4 @@
-ARG BYOK_TOOL_IMAGE=registry.redhat.io/lightspeed-rag-tool-tech-preview/lightspeed-rag-tool-rhel9:latest
+ARG BYOK_TOOL_IMAGE=registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-rag-tool-rhel9:latest
 ARG UBI_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi:latest
 ARG HERMETIC=false
 FROM ${UBI_BASE_IMAGE}
@@ -8,13 +8,13 @@ ARG VECTOR_DB_INDEX=vector_db_index
 ARG BYOK_TOOL_IMAGE
 ARG UBI_BASE_IMAGE
 ARG HERMETIC
-RUN dnf install -y buildah python3.11 python3.11-pip
+RUN dnf install -y buildah python3.11 python3.11-pip && dnf clean all
 
 USER 0
 WORKDIR /workdir
 
-COPY requirements.gpu.txt .
-RUN pip3.11 install --no-cache-dir --no-deps -r requirements.gpu.txt
+COPY requirements.cpu.txt .
+RUN pip3.11 install --no-cache-dir --no-deps -r requirements.cpu.txt
 
 COPY embeddings_model ./embeddings_model
 ENV HERMETIC=$HERMETIC
@@ -45,8 +45,6 @@ LABEL url="https://github.com/openshift/lightspeed-rag-content"
 LABEL vendor="Red Hat, Inc."
 LABEL version=0.0.1
 LABEL summary="Red Hat OpenShift Lightspeed BYO Knowledge Tools"
-
-USER 65532:65532
 
 ENV _BUILDAH_STARTED_IN_USERNS=""
 ENV BUILDAH_ISOLATION=chroot

--- a/byok/README.md
+++ b/byok/README.md
@@ -13,7 +13,7 @@ for resulting image containing the RAG database.
 
 ## These steps will be done during the OLS build:
 
-Use for your experimentation. Once released, MY_BYOK_TOOL_IMAGE will be an image tag under registry.redhat.io/openshift-lightspeed-tech-preview.
+Use for your experimentation. Once released, MY_BYOK_TOOL_IMAGE will be registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-rag-tool-rhel9:latest.
 
 ### Build and push the BYOK tool image.
 
@@ -23,14 +23,25 @@ $ podman build --build-arg BYOK_TOOL_IMAGE=$MY_BYOK_TOOL_IMAGE -t $MY_BYOK_TOOL_
 $ podman push $MY_BYOK_TOOL_IMAGE
 ```
 
-## This is how the user runs the BYOK tool:
+## This is how to run the BYOK tool you built yourself:
 
 ```bash
 $ MY_BYOK_TOOL_IMAGE=quay.io/$USERNAME/byok_tool:0.0.1
 $ podman run -e OUT_IMAGE_TAG=my-byok-image -it --rm --device=/dev/fuse \
+  -v $XDG_RUNTIME_DIR/containers/auth.json:/run/user/0/containers/auth.json:Z \
   -v <dir_tree_with_markdown_files>:/markdown:Z \
   -v <dir_for_image_tar>:/output:Z \
   $MY_BYOK_TOOL_IMAGE
+```
+
+The released version of the tool can be run as follows:
+
+```bash
+$ podman run -it --rm --device=/dev/fuse \
+  -v $XDG_RUNTIME_DIR/containers/auth.json:/run/user/0/containers/auth.json:Z \
+  -v <dir_tree_with_markdown_files>:/markdown:Z \
+  -v <dir_for_image_tar>:/output:Z \
+  registry.redhat.io/openshift-lightspeed-tech-preview/lightspeed-rag-tool-rhel9:latest
 ```
 
 The tool runs on CPUs, not GPUs.
@@ -41,6 +52,7 @@ There are two mandatory parameters:
 - <dir_for_image_tar> is the directory where the resulting image tar archive will be written. It needs to be writable.
 
 The OUT_IMAGE_TAG environment variable can be used to override the tag of the generated image. It defaults to "byok-image".
+The VECTOR_DB_INDEX environment variable can be used to override the database index. It defaults to "vector_db_index".
 
 The BYOK tool will produce the resulting container image as a tar archive named `<dir_for_image_tar>/my-byok-image.tar`. Existing `<dir_for_image_tar>/my-byok-image.tar` will be overwritten.
 


### PR DESCRIPTION
After the BYOK tool was built in Konflux, the following issues were uncovered:

- running the image as a non-0 USER causes odd issues inside the container - buildah using the wrong HOME directory, etc
- the image name of the tool image used in the tool build is incorrect
- the size of the image has grown to 7.6GB, which makes the tool practically unusable for interactive use due to the time it takes to pull an image of that size
- the released image located in registry.redhat.io which requires authentication now requires login credentials passed to the tool so it can pull its own image during image build

JIRA: https://issues.redhat.com/browse/OLS-1836
