### PR TITLE
remove tooltip after each section title which stripping html

### DIFF
--- a/scripts/html_chunking/html-stripper.py
+++ b/scripts/html_chunking/html-stripper.py
@@ -129,6 +129,8 @@ def strip_html_content(
                 chapters = [body_content]
 
             for chapter in chapters:
+                for tooltip in chapter.find_all("rh-tooltip"):
+                    tooltip.decompose()
                 new_soup.body.append(chapter.extract())
             
             soup = new_soup


### PR DESCRIPTION
on 23 HTML index files

w/o the fix:
stripping: ~30 sec
total_chunks: 11512

w/ fix:
stripping: ~20 sec
total_chunks: 8636

reduce in chunk reduces the final embedding

from
``` html
     <h2>
      Chapter 1. Overview
      <rh-tooltip>
       <rh-button>
        <rh-icon>
        </rh-icon>
       </rh-button>
       <div>
        Copy link
        Link copied to clipboard!
        <rh-icon>
        </rh-icon>
       </div>
      </rh-tooltip>
     </h2>
```
to
```
     <h2>
      Chapter 1. Overview
     </h2>
```