### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for lightspeed-rag-tool

### DIFF
--- a/byok/Containerfile.tool
+++ b/byok/Containerfile.tool
@@ -34,12 +34,13 @@ COPY LICENSE /licenses/
 
 # Labels for enterprise contract
 LABEL com.redhat.component=openshift-lightspeed-rag-content
+LABEL cpe="cpe:/a:redhat:openshift_lightspeed:1::el9"
 LABEL description="Red Hat OpenShift Lightspeed BYO Knowledge Tools"
 LABEL distribution-scope=private
 LABEL io.k8s.description="Red Hat OpenShift Lightspeed BYO Knowledge Tools"
 LABEL io.k8s.display-name="Openshift Lightspeed BYO Knowledge Tools"
 LABEL io.openshift.tags="openshift,lightspeed,ai,assistant,rag"
-LABEL name=openshift-lightspeed-rag-content
+LABEL name="openshift-lightspeed-tech-preview/lightspeed-rag-tool-rhel9"
 LABEL release=0.0.1
 LABEL url="https://github.com/openshift/lightspeed-rag-content"
 LABEL vendor="Red Hat, Inc."


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
