### PR TITLE
OLS-2889: Correct handling of the --hermetic-build command line parameter in RAG build scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ help: ## Show this help screen
 	@grep -E '^[ a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
 	@echo ''
-	
+
 model-safetensors: ## Download model.safetensors to embeddings_model
 	@if [ ! -f embeddings_model/model.safetensors ]; then \
 		echo "Downloading model.safetensors..."; \

--- a/lsc/custom_processor.py
+++ b/lsc/custom_processor.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import argparse
 import os
 import sys, logging
 
@@ -59,6 +60,18 @@ class RunbooksMetadataProcessor(MetadataProcessor):
         return self.root_url + file_path.removeprefix(self.plaintext_root_dir)
 
 
+def str2bool(value: str | bool) -> bool:
+    """Parse CLI boolean; argparse's type=bool is wrong (bool('False') is True)."""
+    if isinstance(value, bool):
+        return value
+    s = str(value).strip().lower()
+    if s in ("", "0", "n", "no", "f", "false", "off"):
+        return False
+    if s in ("1", "y", "yes", "t", "true", "on"):
+        return True
+    raise argparse.ArgumentTypeError(f"expected a boolean string, got {value!r}")
+
+
 if __name__ == "__main__":
 
     parser = utils.get_common_arg_parser()
@@ -75,7 +88,11 @@ if __name__ == "__main__":
         "-rbp", "--runbooks-plaintext-dir", help="Directory with runbooks plaintext"
     )
     parser.add_argument(
-        "-hb", "--hermetic-build", type=bool, default=False, help="Hermetic build"
+        "-hb",
+        "--hermetic-build",
+        type=str2bool,
+        default=False,
+        help="Hermetic build (true/false, yes/no, 1/0)",
     )
     args = parser.parse_args()
 

--- a/scripts/generate_embeddings.py
+++ b/scripts/generate_embeddings.py
@@ -99,6 +99,18 @@ def got_whitespace(text: str) -> bool:
     return False
 
 
+def str2bool(value: str | bool) -> bool:
+    """Parse CLI boolean; argparse's type=bool is wrong (bool('False') is True)."""
+    if isinstance(value, bool):
+        return value
+    s = str(value).strip().lower()
+    if s in ("", "0", "n", "no", "f", "false", "off"):
+        return False
+    if s in ("1", "y", "yes", "t", "true", "on"):
+        return True
+    raise argparse.ArgumentTypeError(f"expected a boolean string, got {value!r}")
+
+
 if __name__ == "__main__":
 
     start_time = time.time()
@@ -134,7 +146,11 @@ if __name__ == "__main__":
     parser.add_argument("-i", "--index", help="Product index")
     parser.add_argument("-v", "--ocp-version", help="OCP version")
     parser.add_argument(
-        "-hb", "--hermetic-build", type=bool, default=False, help="Hermetic build"
+        "-hb",
+        "--hermetic-build",
+        type=str2bool,
+        default=False,
+        help="Hermetic build (true/false, yes/no, 1/0)",
     )
     args = parser.parse_args()
     print(f"Arguments used: {args}")


### PR DESCRIPTION
In the RAG build scripts it is impossible to turn on checking of documentation URLs from the command line, due to the --hermetic-build <flag> command line parameter setting “hermetic-build” for any value of the flag.

JIRA: https://redhat.atlassian.net/browse/OLS-2889