### PR TITLE
Add risk level rubric to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,32 +28,4 @@ When finishing a development branch:
 
 ## Risk Levels
 
-When creating Jira tickets for this repo, assign a risk level in the description.
-
-| Level | Customer Impact | Review Requirements | Automation |
-|-------|----------------|---------------------|------------|
-| Risk 1 | Very little impact if change goes wrong | No human code review required | Fully automated implementation |
-| Risk 2 | Medium impact if change causes problems | 1 human reviewer required | Automated implementation with human review gate |
-| Risk 3 | Major impact — risk of losing customers if a bug is introduced | 2+ human reviewers required | Human-driven implementation |
-
-### Classification Examples
-
-| Change Type | Risk Level |
-|-------------|------------|
-| Doc source URL updates | 1 |
-| Dependency version bump | 1 |
-| Embedding pipeline parameter tuning | 2 |
-| Chunking strategy changes | 2 |
-| Vector store schema/index changes | 3 |
-| Embedding model changes | 3 |
-
-### Jira Description Format
-
-Include this section in every ticket description:
-
-```
-## Risk Level
-
-Risk {1|2|3} — {one-line impact summary}
-Rationale: {why this classification, referencing the rubric}
-```
+Risk levels are enforced via a PreToolUse hook before every Jira create/edit call. The rubric and classification examples live in [lightspeed-team-harness/hooks/risk-rubric.md](https://github.com/openshift/lightspeed-team-harness/blob/main/hooks/risk-rubric.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,35 @@ When finishing a development branch:
 2. Squash commits with the Jira-prefixed message
 3. Push to the contributor's fork remote (not `origin`)
 4. Create the PR against `origin/main` using `--head <user>:<branch>`
+
+## Risk Levels
+
+When creating Jira tickets for this repo, assign a risk level in the description.
+
+| Level | Customer Impact | Review Requirements | Automation |
+|-------|----------------|---------------------|------------|
+| Risk 1 | Very little impact if change goes wrong | No human code review required | Fully automated implementation |
+| Risk 2 | Medium impact if change causes problems | 1 human reviewer required | Automated implementation with human review gate |
+| Risk 3 | Major impact — risk of losing customers if a bug is introduced | 2+ human reviewers required | Human-driven implementation |
+
+### Classification Examples
+
+| Change Type | Risk Level |
+|-------------|------------|
+| Doc source URL updates | 1 |
+| Dependency version bump | 1 |
+| Embedding pipeline parameter tuning | 2 |
+| Chunking strategy changes | 2 |
+| Vector store schema/index changes | 3 |
+| Embedding model changes | 3 |
+
+### Jira Description Format
+
+Include this section in every ticket description:
+
+```
+## Risk Level
+
+Risk {1|2|3} — {one-line impact summary}
+Rationale: {why this classification, referencing the rubric}
+```


### PR DESCRIPTION
Adds a Risk Levels section to AGENTS.md defining risk 1/2/3 classification with repo-specific examples and Jira description format.