### PR TITLE
OLS-2607 update specs for OKP adoption

### DIFF
--- a/.ai/spec/what/container-build.md
+++ b/.ai/spec/what/container-build.md
@@ -2,65 +2,67 @@
 
 This spec defines the rules for building container images, hermetic build support, and CI/CD pipeline behavior.
 
-## Behavioral Rules -- Main RAG Content Image
+## DEPRECATED: Behavioral Rules -- Main RAG Content Image
 
-1. Two Containerfiles exist for building the main RAG content image:
+> The main RAG content image is deprecated. OCP product docs are now served by OKP via the RHOKP sidecar deployed by the operator. Only the BYOK tool image is actively maintained.
+
+1. [DEPRECATED] Two Containerfiles exist for building the main RAG content image:
    - **`lsc/Containerfile.konflux`** (primary): Uses the lsc library pipeline with `custom_processor.py`, produces `llamastack-faiss` indexes. Used by the `lightspeed-ocp-rag-push/pull-request` Konflux pipelines.
    - **Root `Containerfile`** (alternative): Uses the plaintext pipeline with `scripts/generate_embeddings.py`, produces LlamaIndex FAISS indexes. Used by the `own-app-lightspeed-rag-content` Konflux pipelines.
 
-2. Both Containerfiles follow a multi-stage build: a builder stage generates all vector indexes, then a minimal final stage copies only the output artifacts.
+2. [DEPRECATED] Both Containerfiles follow a multi-stage build: a builder stage generates all vector indexes, then a minimal final stage copies only the output artifacts.
 
-3. Both builder stages iterate over all version directories in `ocp-product-docs-plaintext/` and generate one index per version. Each version's index includes both OCP docs and runbooks.
+3. [DEPRECATED] Both builder stages iterate over all version directories in `ocp-product-docs-plaintext/` and generate one index per version. Each version's index includes both OCP docs and runbooks.
 
-4. The root Containerfile creates a `latest` symlink pointing to the highest version directory (determined by version-aware sorting). The lsc Containerfile does not create this symlink.
+4. [DEPRECATED] The root Containerfile creates a `latest` symlink pointing to the highest version directory (determined by version-aware sorting). The lsc Containerfile does not create this symlink.
 
-5. The final image uses `ubi9/ubi-minimal` (pinned by digest) as base and contains only:
+5. [DEPRECATED] The final image uses `ubi9/ubi-minimal` (pinned by digest) as base and contains only:
    - `/rag/vector_db/ocp_product_docs/` -- all version index directories.
    - `/rag/embeddings_model/` -- the sentence-transformer model.
    - `/licenses/LICENSE` -- Apache 2.0 license for enterprise contract compliance.
 
-6. The final image runs as non-root user (UID 65532, GID 65532).
+6. [DEPRECATED] The final image runs as non-root user (UID 65532, GID 65532).
 
-7. The embedding model's `model.safetensors` file is sourced based on the `HERMETIC` build arg:
+7. [DEPRECATED] The embedding model's `model.safetensors` file is sourced based on the `HERMETIC` build arg:
    - `HERMETIC=false`: Downloaded from HuggingFace at build time (URL pinned to a specific commit hash).
    - `HERMETIC=true`: Copied from the Cachi2 prefetch cache at `/cachi2/output/deps/generic/model.safetensors`.
 
-8. Container labels must satisfy Red Hat enterprise contract requirements: `com.redhat.component`, `cpe`, `description`, `distribution-scope`, `io.k8s.description`, `io.k8s.display-name`, `io.openshift.tags`, `name`, `release`, `url`, `vendor`, `version`, `summary`.
+8. [DEPRECATED] Container labels must satisfy Red Hat enterprise contract requirements: `com.redhat.component`, `cpe`, `description`, `distribution-scope`, `io.k8s.description`, `io.k8s.display-name`, `io.openshift.tags`, `name`, `release`, `url`, `vendor`, `version`, `summary`.
 
-9. The root Containerfile supports two base images selected by `FLAVOR` build arg (`cpu` or `gpu`). The lsc Containerfile is GPU-only (always uses the CUDA base image).
+9. [DEPRECATED] The root Containerfile supports two base images selected by `FLAVOR` build arg (`cpu` or `gpu`). The lsc Containerfile is GPU-only (always uses the CUDA base image).
 
 ## Behavioral Rules -- BYOK Tool Image
 
-9. The BYOK tool image is built from `byok/Containerfile.tool`. It contains: `buildah`, Python 3.12, CPU Python dependencies, the embedding model, the BYOK embedding script (`generate_embeddings_tool.py`), and the output Containerfile template (`Containerfile.output`).
+10. The BYOK tool image is built from `byok/Containerfile.tool`. It contains: `buildah`, Python 3.12, CPU Python dependencies, the embedding model, the BYOK embedding script (`generate_embeddings_tool.py`), and the output Containerfile template (`Containerfile.output`).
 
-10. The tool image's CMD runs `buildah build` to produce the customer's RAG image from Markdown content mounted at `/markdown`, then pushes the result as a tar archive to `/output/`.
+11. The tool image's CMD runs `buildah build` to produce the customer's RAG image from Markdown content mounted at `/markdown`, then pushes the result as a tar archive to `/output/`.
 
 ## Behavioral Rules -- Hermetic Builds
 
-11. Hermetic builds (`HERMETIC=true`) operate without network access during the container build step.
+12. Hermetic builds (`HERMETIC=true`) operate without network access during the container build step.
 
-12. All Python packages are pre-fetched via Cachi2 and installed from the prefetch cache. The requirements files include package hashes for verification.
+13. All Python packages are pre-fetched via Cachi2 and installed from the prefetch cache. The requirements files include package hashes for verification.
 
-13. The embedding model binary (`model.safetensors`) is fetched as a generic artifact via Cachi2 with a pinned SHA256 hash defined in `artifacts.lock.yaml`.
+14. The embedding model binary (`model.safetensors`) is fetched as a generic artifact via Cachi2 with a pinned SHA256 hash defined in `artifacts.lock.yaml`.
 
-14. RPM packages are resolved and locked via `rpms.in.yaml` (input specification) and `rpms.lock.yaml` (locked versions).
+15. RPM packages are resolved and locked via `rpms.in.yaml` (input specification) and `rpms.lock.yaml` (locked versions).
 
-15. URL reachability validation is skipped during hermetic builds (the `--hermetic-build true` flag is passed to the embedding script).
+16. URL reachability validation is skipped during hermetic builds (the `--hermetic-build true` flag is passed to the embedding script).
 
 ## Behavioral Rules -- CI/CD (Konflux/Tekton)
 
-16. Six pipelines exist as Tekton PipelineRun definitions:
-    - `lightspeed-ocp-rag-push/pull-request` -- primary RAG content image using `lsc/Containerfile.konflux`.
-    - `own-app-lightspeed-rag-content-push/pull-request` -- alternative RAG content image using root `Containerfile`.
-    - `lightspeed-rag-tool-push/pull-request` -- BYOK tool image using `byok/Containerfile.tool`.
+17. Six pipelines exist as Tekton PipelineRun definitions:
+    - [DEPRECATED] `lightspeed-ocp-rag-push/pull-request` -- primary RAG content image using `lsc/Containerfile.konflux`. No longer built; OCP docs served by OKP.
+    - [DEPRECATED] `own-app-lightspeed-rag-content-push/pull-request` -- alternative RAG content image using root `Containerfile`. No longer built; OCP docs served by OKP.
+    - `lightspeed-rag-tool-push/pull-request` -- BYOK tool image using `byok/Containerfile.tool`. Actively maintained.
 
-17. Push pipelines trigger on merge to `main`. Pull-request pipelines trigger on PRs.
+18. Push pipelines trigger on merge to `main`. Pull-request pipelines trigger on PRs.
 
-18. All pipelines use hermetic builds with Cachi2 prefetch for pip packages, RPMs, and generic artifacts.
+19. All pipelines use hermetic builds with Cachi2 prefetch for pip packages, RPMs, and generic artifacts.
 
-19. The primary RAG image (`lsc/Containerfile.konflux`) always builds with GPU. The alternative RAG image (root `Containerfile`) builds with `FLAVOR=gpu` in CI.
+20. [DEPRECATED] The primary RAG image (`lsc/Containerfile.konflux`) always builds with GPU. The alternative RAG image (root `Containerfile`) builds with `FLAVOR=gpu` in CI.
 
-20. An integration test verifies the built image contains the expected paths: an `index_store.json` file under `/rag/vector_db/ocp_product_docs/{version}/` for every OCP version present in `ocp-product-docs-plaintext/`, and `config.json` under `/rag/embeddings_model/`.
+21. [DEPRECATED] An integration test verifies the built image contains the expected paths: an `index_store.json` file under `/rag/vector_db/ocp_product_docs/{version}/` for every OCP version present in `ocp-product-docs-plaintext/`, and `config.json` under `/rag/embeddings_model/`.
 
 ## Configuration Surface
 

--- a/.ai/spec/what/content-sources.md
+++ b/.ai/spec/what/content-sources.md
@@ -1,52 +1,62 @@
 # Content Sources
 
+> **OKP adoption notice:** With OKP adoption, the only active content source is customer-supplied Markdown for BYOK. OCP product documentation, runbooks, and OKP errata content sources are deprecated — OCP docs are now served directly by OKP via the RHOKP sidecar deployed by the operator.
+
 This spec defines the rules for acquiring, processing, and organizing input content before it enters the embedding pipeline.
 
-## Behavioral Rules -- OCP Product Documentation
+## DEPRECATED: Behavioral Rules -- OCP Product Documentation
 
-1. The source is the `openshift/openshift-docs` GitHub repository. Each OCP version is cloned from its corresponding `enterprise-{version}` branch (e.g., `enterprise-4.18`).
+> These content acquisition rules apply only to the deprecated main RAG content image. OCP product documentation is now served by OKP via the RHOKP sidecar.
 
-2. AsciiDoc source files are converted to plaintext using the `asciidoctor` CLI with a custom Ruby text converter extension. Per-version attribute files provide version-specific AsciiDoc substitution values.
+1. [DEPRECATED] The source is the `openshift/openshift-docs` GitHub repository. Each OCP version is cloned from its corresponding `enterprise-{version}` branch (e.g., `enterprise-4.18`).
 
-3. The topic map file (`_topic_maps/_topic_map.yml`) with the distro filter `openshift-enterprise` determines which AsciiDoc files to convert. Only files referenced in the topic map for the `openshift-enterprise` distribution are included.
+2. [DEPRECATED] AsciiDoc source files are converted to plaintext using the `asciidoctor` CLI with a custom Ruby text converter extension. Per-version attribute files provide version-specific AsciiDoc substitution values.
 
-4. Converted plaintext files are stored in `ocp-product-docs-plaintext/{version}/` with the directory hierarchy from the source repository preserved.
+3. [DEPRECATED] The topic map file (`_topic_maps/_topic_map.yml`) with the distro filter `openshift-enterprise` determines which AsciiDoc files to convert. Only files referenced in the topic map for the `openshift-enterprise` distribution are included.
 
-5. Files listed in the exclusion configuration must be removed after conversion. The exclusion list is a newline-delimited file of relative paths within the version directory.
+4. [DEPRECATED] Converted plaintext files are stored in `ocp-product-docs-plaintext/{version}/` with the directory hierarchy from the source repository preserved.
 
-6. All currently supported OCP versions must have a corresponding directory. Each directory name is a version string (e.g., `4.16`, `4.17`, `4.18`, `4.19`, `4.20`, `4.21`, `4.22`).
+5. [DEPRECATED] Files listed in the exclusion configuration must be removed after conversion. The exclusion list is a newline-delimited file of relative paths within the version directory.
 
-7. The plaintext docs and runbooks are committed to the repository and kept up to date. Content acquisition scripts exist for refreshing them, but the committed content is what the production build uses.
+6. [DEPRECATED] All currently supported OCP versions must have a corresponding directory. Each directory name is a version string (e.g., `4.16`, `4.17`, `4.18`, `4.19`, `4.20`, `4.21`, `4.22`).
 
-## Behavioral Rules -- Runbooks
+7. [DEPRECATED] The plaintext docs and runbooks are committed to the repository and kept up to date. Content acquisition scripts exist for refreshing them, but the committed content is what the production build uses.
 
-8. The source is the `openshift/runbooks` GitHub repository, `master` branch, restricted to the `alerts/` directory only.
+## DEPRECATED: Behavioral Rules -- Runbooks
 
-9. Acquisition uses sparse checkout with blob filtering (`--filter=blob:none`) to avoid cloning the full repository history.
+> These content acquisition rules apply only to the deprecated main RAG content image. OCP product documentation is now served by OKP via the RHOKP sidecar.
 
-10. Only Markdown (`.md`) files are retained. `README.md` files, empty directories, and `deprecated/` directories are removed after checkout.
+8. [DEPRECATED] The source is the `openshift/runbooks` GitHub repository, `master` branch, restricted to the `alerts/` directory only.
 
-11. Runbooks are stored in `runbooks/alerts/` with operator-specific subdirectories preserved (e.g., `runbooks/alerts/cluster-etcd-operator/`).
+9. [DEPRECATED] Acquisition uses sparse checkout with blob filtering (`--filter=blob:none`) to avoid cloning the full repository history.
 
-## Behavioral Rules -- OKP (Errata) Content
+10. [DEPRECATED] Only Markdown (`.md`) files are retained. `README.md` files, empty directories, and `deprecated/` directories are removed after checkout.
 
-12. OKP files are Markdown documents with TOML frontmatter delimited by `+++` markers.
+11. [DEPRECATED] Runbooks are stored in `runbooks/alerts/` with operator-specific subdirectories preserved (e.g., `runbooks/alerts/cluster-etcd-operator/`).
 
-13. OKP files are filtered by project name via case-insensitive substring matching against the `portal_product_names` list in the TOML metadata's `extra` section. A project name like "OpenStack" matches any product name containing that substring (e.g., "Red Hat OpenStack Platform").
+## DEPRECATED: Behavioral Rules -- OKP (Errata) Content
 
-14. OKP files must have both a non-empty `reference_url` in `extra` and a non-empty `title` in the TOML metadata to be included. Files missing either field are skipped with a warning.
+> OKP serves content directly via Solr; build-time errata ingestion into FAISS is no longer needed.
+
+12. [DEPRECATED] OKP files are Markdown documents with TOML frontmatter delimited by `+++` markers.
+
+13. [DEPRECATED] OKP files are filtered by project name via case-insensitive substring matching against the `portal_product_names` list in the TOML metadata's `extra` section. A project name like "OpenStack" matches any product name containing that substring (e.g., "Red Hat OpenStack Platform").
+
+14. [DEPRECATED] OKP files must have both a non-empty `reference_url` in `extra` and a non-empty `title` in the TOML metadata to be included. Files missing either field are skipped with a warning.
 
 ## Behavioral Rules -- Document Metadata
+
+> Rules 15–20 remain active for BYOK content. OCP docs and runbooks metadata rules are deprecated alongside the content sources above.
 
 15. Every document processed for embedding must carry at minimum two metadata fields: `docs_url` (source URL) and `title` (document title). The lsc library additionally includes `url_reachable` (boolean indicating URL validity) to support the `unreachable_action` filtering rules below. The plaintext pipeline does not include `url_reachable` in metadata.
 
 16. `title` is extracted from the first line of the document file, stripping any leading `# ` Markdown heading prefix. For OKP files, `title` comes from the TOML frontmatter instead.
 
 17. `docs_url` is derived from the file path using content-type-specific URL construction rules:
-    - **OCP docs**: `https://docs.openshift.com/container-platform/{version}/{relative_path}.html` -- the `.txt` extension is replaced with `.html`, and the embeddings root directory prefix is stripped.
-    - **Runbooks**: `https://github.com/openshift/runbooks/blob/master/alerts/{relative_path}` -- the runbooks root directory prefix is stripped.
+    - [DEPRECATED] **OCP docs**: `https://docs.openshift.com/container-platform/{version}/{relative_path}.html` -- the `.txt` extension is replaced with `.html`, and the embeddings root directory prefix is stripped.
+    - [DEPRECATED] **Runbooks**: `https://github.com/openshift/runbooks/blob/master/alerts/{relative_path}` -- the runbooks root directory prefix is stripped.
     - **BYOK content**: Defaults to the file path. If YAML frontmatter with a `url` field is present, that URL is used instead.
-    - **OKP content**: The `reference_url` from the TOML frontmatter `extra` section.
+    - [DEPRECATED] **OKP content**: The `reference_url` from the TOML frontmatter `extra` section.
 
 18. URL reachability is validated via HTTP GET with retries. The lsc library's `MetadataProcessor` uses configurable retries (default 3) with a 30-second timeout. The plaintext pipeline's `ping_url` uses a single attempt with a 30-second timeout. Validation is skipped during hermetic builds in both pipelines.
 
@@ -60,19 +70,19 @@ This spec defines the rules for acquiring, processing, and organizing input cont
 
 ## Configuration Surface
 
-- `config/exclude.conf` -- newline-delimited list of relative file paths to exclude from OCP docs after conversion.
-- `ocp-product-docs-plaintext/{version}/` directories -- each directory name is an OCP version string. Adding or removing directories changes which versions are indexed.
-- `scripts/asciidoctor-text/{version}/attributes.yaml` (and `lsc/scripts/asciidoctor-text/{version}/attributes.yaml`) -- per-version AsciiDoc attribute files providing version-specific substitution values.
+- `config/exclude.conf` -- [DEPRECATED] newline-delimited list of relative file paths to exclude from OCP docs after conversion.
+- `ocp-product-docs-plaintext/{version}/` directories -- [DEPRECATED] each directory name is an OCP version string. Adding or removing directories changes which versions are indexed.
+- `scripts/asciidoctor-text/{version}/attributes.yaml` (and `lsc/scripts/asciidoctor-text/{version}/attributes.yaml`) -- [DEPRECATED] per-version AsciiDoc attribute files providing version-specific substitution values.
 - `--hermetic-build` / `-hb` CLI flag -- disables URL reachability validation.
 - `--folder` / `-f` CLI flag -- specifies the input document directory.
-- `--runbooks` / `-r` CLI flag -- specifies the runbooks directory.
+- `--runbooks` / `-r` CLI flag -- [DEPRECATED] specifies the runbooks directory.
 
 ## Constraints
 
-1. AsciiDoc conversion requires `asciidoctor` and `ruby` to be installed on the system. These are not Python dependencies and must be available in the build environment.
+1. [DEPRECATED] AsciiDoc conversion requires `asciidoctor` and `ruby` to be installed on the system. These are not Python dependencies and must be available in the build environment.
 
-2. Content acquisition scripts require network access to clone from GitHub. The production container build uses pre-committed content and does not run these scripts -- they are developer/maintenance tools.
+2. [DEPRECATED] Content acquisition scripts require network access to clone from GitHub. The production container build uses pre-committed content and does not run these scripts -- they are developer/maintenance tools.
 
-3. The OCP documentation repository is large. Single-branch cloning (`--single-branch`) is required to keep clone times manageable.
+3. [DEPRECATED] The OCP documentation repository is large. Single-branch cloning (`--single-branch`) is required to keep clone times manageable.
 
-4. Runbook acquisition uses sparse checkout to avoid downloading irrelevant content from the runbooks repository.
+4. [DEPRECATED] Runbook acquisition uses sparse checkout to avoid downloading irrelevant content from the runbooks repository.

--- a/.ai/spec/what/embedding-pipeline.md
+++ b/.ai/spec/what/embedding-pipeline.md
@@ -1,5 +1,7 @@
 # Embedding Pipeline
 
+> **OKP adoption notice:** With OKP adoption, the embedding pipeline is used only for BYOK customer content. OCP product docs embedding is deprecated — product documentation is served by OKP via the RHOKP sidecar deployed by the operator.
+
 This spec defines the shared behavioral rules that all pipeline implementations (plaintext, HTML, lsc library) must satisfy. Individual pipeline architectures are documented in the corresponding `how/` specs.
 
 ## Behavioral Rules -- Chunking
@@ -84,6 +86,6 @@ This spec defines the shared behavioral rules that all pipeline implementations 
 
 ## Planned Changes
 
-- [PLANNED: OLS-1729] Embedding model fine-tuning -- generate domain-specific vocabulary from OCP docs and augment the embedding model's vocabulary corpus.
-- [PLANNED: OLS-2294] Add metadata generation stage -- add a dedicated metadata generation/enrichment step to the pipeline.
-- [PLANNED: OLS-2903] OKP-based RAG -- integrate OKP (OpenShift Knowledge Platform) errata content.
+- [REMOVED: OLS-1729] ~~Embedding model fine-tuning~~ -- superseded by OKP adoption; OCP docs no longer use FAISS embeddings.
+- [REMOVED: OLS-2294] ~~Add metadata generation stage~~ -- superseded by OKP adoption; OCP docs pipeline is deprecated.
+- [REMOVED: OLS-2903] ~~OKP-based RAG~~ -- completed; OKP is now the primary OCP docs retrieval mechanism via the RHOKP sidecar.

--- a/.ai/spec/what/system-overview.md
+++ b/.ai/spec/what/system-overview.md
@@ -1,21 +1,23 @@
 # System Overview
 
-OpenShift LightSpeed RAG Content is a build-time artifact producer for the OpenShift LightSpeed AI assistant. It converts OpenShift product documentation and operational runbooks into pre-built FAISS vector indexes, packages them alongside the embedding model into container images, and publishes those images for consumption by the lightspeed-service at runtime.
+> **Deprecation notice:** The main RAG content image (pre-built FAISS vector indexes of OCP product documentation) is deprecated. OCP product documentation is now served by the Offline Knowledge Portal (OKP) via the RHOKP sidecar deployed by the operator. This repository now provides BYOK (Bring Your Own Knowledge) tooling only — a container image that lets customers build custom RAG indexes from their own Markdown content.
+
+OpenShift LightSpeed RAG Content is a BYOK tooling provider for the OpenShift LightSpeed AI assistant. It packages an embedding model and build tools into a container image that customers use to produce custom FAISS vector indexes from their own Markdown content. The resulting BYOK indexes are consumed by lightspeed-service at runtime.
 
 ## Behavioral Rules
 
-1. The project produces pre-built FAISS vector indexes from three content sources: OCP product documentation, OpenShift alert runbooks, and customer-supplied Markdown (BYOK). The indexes are packaged as container images consumed by lightspeed-service.
+1. The project produces a BYOK tool image that customers use to build custom FAISS vector indexes from customer-supplied Markdown content. The resulting indexes are packaged as container images consumed by lightspeed-service. [DEPRECATED: The project previously also produced pre-built indexes from OCP product documentation and OpenShift alert runbooks. OCP docs are now served by OKP via the RHOKP sidecar.]
 
-2. The project is a build-time artifact producer. All computation -- document conversion, chunking, embedding generation, and vector store creation -- happens during the container image build or via offline scripts. The project never runs at runtime.
+2. The project is a build-time artifact producer. All computation -- document conversion, chunking, embedding generation, and vector store creation -- happens during the container image build or via offline scripts. The project never runs at runtime. This now applies to BYOK content only.
 
-3. Two container image artifacts are produced:
-   - **Main RAG content image**: Contains all OCP version vector indexes, the `latest` symlink, and the embedding model. Consumed by lightspeed-service as a volume mount.
+3. One container image artifact is produced:
    - **BYOK tool image**: Contains buildah, the embedding toolchain, and the embedding model. Used by customers to build custom RAG images from their own Markdown content.
+   - [DEPRECATED: **Main RAG content image** — previously contained all OCP version vector indexes, the `latest` symlink, and the embedding model. No longer built; OCP docs are served by OKP.]
 
-4. Three pipeline implementations exist for generating vector indexes:
-   - **lsc library pipeline** (`lsc/Containerfile.konflux` + `lsc/custom_processor.py`): The primary Konflux CI pipeline. Uses the lsc library (`lsc/src/lightspeed_rag_content/`) and produces `llamastack-faiss` indexes. Used by the `lightspeed-ocp-rag-push` and `lightspeed-ocp-rag-pull-request` Tekton pipelines.
-   - **Plaintext pipeline** (`scripts/generate_embeddings.py` + root `Containerfile`): An alternative build variant. Processes pre-converted plaintext OCP docs and Markdown runbooks using plain LlamaIndex FAISS. Used by the `own-app-lightspeed-rag-content` Tekton pipelines.
-   - **HTML pipeline** (`scripts/html_embeddings/`): Downloads HTML documentation from the Red Hat portal, strips non-content markup, performs semantic HTML chunking, and generates embeddings. Not used by any CI pipeline.
+4. Three pipeline implementations exist for generating vector indexes, all deprecated for OCP docs production:
+   - [DEPRECATED] **lsc library pipeline** (`lsc/Containerfile.konflux` + `lsc/custom_processor.py`): Was the primary Konflux CI pipeline. Used the lsc library and produced `llamastack-faiss` indexes. Used by the `lightspeed-ocp-rag-push` and `lightspeed-ocp-rag-pull-request` Tekton pipelines.
+   - [DEPRECATED for OCP docs] **Plaintext pipeline** (`scripts/generate_embeddings.py` + root `Containerfile`): Was an alternative build variant. Processed pre-converted plaintext OCP docs and Markdown runbooks using plain LlamaIndex FAISS. The BYOK path in `generate_embeddings_tool.py` remains active.
+   - [DEPRECATED] **HTML pipeline** (`scripts/html_embeddings/`): Downloaded HTML documentation from the Red Hat portal, stripped non-content markup, performed semantic HTML chunking, and generated embeddings. Was never used by any CI pipeline.
 
 5. The embedding model must be redistributable under an Apache 2.0 compatible license.
 
@@ -23,23 +25,28 @@ OpenShift LightSpeed RAG Content is a build-time artifact producer for the OpenS
 
 ## Integration Contract
 
-### Consumed by lightspeed-service
+### BYOK tool image
 
-The main RAG content image is mounted as a volume by lightspeed-service (typically via the OpenShift LightSpeed operator). The service reads:
+The BYOK tool image is used by customers to build custom RAG container images from their own Markdown content. The tool image contains buildah, the embedding toolchain, and the embedding model. Customers mount their Markdown at `/markdown` and the tool produces a RAG image archive at `/output/`.
 
-- `/rag/vector_db/ocp_product_docs/{version}/` -- persisted FAISS vector store files (`docstore.json`, `index_store.json`, `graph_store.json`, `vector_store.json`, `metadata.json`).
+The resulting BYOK RAG images are consumed by lightspeed-service via init containers configured through the operator CRD's `rag[]` entries. Each BYOK index is mounted and registered as a `reference_content` entry.
+
+### DEPRECATED: Main RAG content image
+
+> The main RAG content image is deprecated. OCP product documentation is now served by OKP via the RHOKP sidecar deployed by the operator. The mount paths and integration described below are no longer applicable to new deployments.
+
+Previously, the main RAG content image was mounted as a volume by lightspeed-service. The service read:
+- `/rag/vector_db/ocp_product_docs/{version}/` -- persisted FAISS vector store files.
 - `/rag/vector_db/ocp_product_docs/latest` -- symlink to the highest OCP version directory.
-- `/rag/embeddings_model/` -- the HuggingFace-compatible sentence-transformer model used to embed user queries at runtime.
-
-The service loads these indexes read-only at startup via LlamaIndex's `StorageContext.from_defaults()` and uses the same embedding model to encode queries for vector similarity search.
+- `/rag/embeddings_model/` -- the sentence-transformer model used to embed user queries at runtime.
 
 ### Integration invariant
 
-The embedding model used to generate the indexes must be identical to the model used by lightspeed-service for query embedding. A mismatch produces meaningless similarity scores. The model identity is currently enforced by shipping the model inside the RAG content image and configuring the service to use it via `ols_config.reference_content.embeddings_model_path`.
+The embedding model used to generate BYOK indexes must be identical to the model used by lightspeed-service for BYOK query embedding. A mismatch produces meaningless similarity scores. The model identity is enforced by shipping the model inside the BYOK tool image and configuring the service to use it via `ols_config.reference_content.embeddings_model_path`.
 
 ### Operator integration
 
-The OpenShift LightSpeed operator configures RAG content references via the CRD. Each index entry specifies `product_docs_index_path`, `product_docs_index_id`, and `product_docs_origin`. The operator mounts the RAG content image and maps these paths. [PLANNED: OLS-1812 -- per-index embedding model path in CRD]
+The OpenShift LightSpeed operator configures BYOK RAG content references via the CRD. Each BYOK index entry specifies `product_docs_index_path`, `product_docs_index_id`, and `product_docs_origin`. The operator mounts BYOK RAG images via init containers and maps these paths.
 
 ## Constraints
 
@@ -51,9 +58,5 @@ The OpenShift LightSpeed operator configures RAG content references via the CRD.
 
 ## Planned Changes
 
-- [PLANNED: OLS-2294] Add metadata generation stage to the pipeline.
-- [PLANNED: OLS-1729] Embedding model fine-tuning -- use fine-tuned models for better domain-specific retrieval accuracy.
-- [PLANNED: OLS-2903] OKP-based RAG -- propose plans to use OKP (OpenShift Knowledge Platform) content with OLS.
-- [PLANNED: OLS-2704] RAG as a service / MCP -- externalize RAG retrieval behind an MCP interface.
-- [PLANNED: OCPSTRAT-1495] Include OCP KCS (Knowledge-Centered Service) content in OLS.
-- [PLANNED: OCPSTRAT-1492] Include OCP layered product knowledge (CNV, ACM, RHOSO) in OLS.
+- [PLANNED: OLS-2704] RAG as a service / MCP -- externalize RAG retrieval behind an MCP interface. Relevant to BYOK.
+- [PLANNED: OLS-1872] BYOK Phase 2 -- one-click import from Git/Confluence.


### PR DESCRIPTION
## Summary
- `system-overview.md`: rewritten for BYOK-only scope, main RAG image deprecated
- `content-sources.md`: OCP docs, runbooks, OKP errata rules marked deprecated, BYOK metadata rules kept
- `embedding-pipeline.md`: scoped to BYOK, removed superseded planned changes
- `container-build.md`: main RAG image rules and pipelines deprecated, BYOK tool image kept

## Context
Design spec: `docs/superpowers/specs/2026-06-17-okp-adoption-design.md` (in ols workspace repo)

OCP product docs are now served by OKP via the RHOKP sidecar. This repo's scope shrinks to BYOK tooling only.

Made with [Cursor](https://cursor.com)