### PR TITLE
OLS-0000: Standardize AGENTS.md content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,16 +7,17 @@ All specifications live in `.ai/spec/`. Start with `.ai/spec/README.md` for proj
 ## Commands
 
 ```bash
-make build-byok-image  # Build the BYOK tool container image
-make test              # Run tests
-make lint              # Lint checks
+make build-image       # Build the RAG content container image
+make verify            # Lint + type checks
+make -C lsc test-unit  # Run unit tests (lsc library)
+make -C lsc verify     # Full lint suite (lsc library)
+make format            # Format code
 ```
 
 ## Conventions
 
 - Python codebase — follow the same style as lightspeed-service (Ruff, Black)
-- BYOK tool image is the primary deliverable; the main RAG content image is deprecated
-- OKP/Solr serves OCP product docs now; this repo only handles customer BYOK content
+- Two build targets: root Makefile for the main RAG content image, `lsc/` for the BYOK tool library
 
 ## Git and PR Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,20 @@
 
 All specifications live in `.ai/spec/`. Start with `.ai/spec/README.md` for project overview, reading order, and structure guide.
 
+## Commands
+
+```bash
+make build-byok-image  # Build the BYOK tool container image
+make test              # Run tests
+make lint              # Lint checks
+```
+
+## Conventions
+
+- Python codebase — follow the same style as lightspeed-service (Ruff, Black)
+- BYOK tool image is the primary deliverable; the main RAG content image is deprecated
+- OKP/Solr serves OCP product docs now; this repo only handles customer BYOK content
+
 ## Git and PR Workflow
 
 ### Commit Messages
@@ -30,6 +44,3 @@ When finishing a development branch:
 3. Push to the contributor's fork remote (not `origin`)
 4. Create the PR against `origin/main` using `--head <user>:<branch>`
 
-## Risk Levels
-
-Risk levels are enforced via a PreToolUse hook before every Jira create/edit call. The rubric and classification examples live in [lightspeed-team-harness/hooks/risk-rubric.md](https://github.com/openshift/lightspeed-team-harness/blob/main/hooks/risk-rubric.md).


### PR DESCRIPTION
## Summary
- Standardize AGENTS.md to include 4 mandatory sections: Specs, Commands, Conventions, Git and PR Workflow
- Normalize file structure: AGENTS.md is the canonical file, CLAUDE.md is a symlink to it
- Remove Risk Levels section (hook doesn't work in all cases)

## Test plan
- [ ] Verify AGENTS.md has all 4 mandatory sections
- [ ] Verify CLAUDE.md is a symlink to AGENTS.md
- [ ] Verify no Risk Levels section remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)